### PR TITLE
Fix bottom overflow in checkout payment screen

### DIFF
--- a/lib/Screen/Payment.dart
+++ b/lib/Screen/Payment.dart
@@ -167,13 +167,9 @@ class StatePayment extends State<Payment> with TickerProviderStateMixin {
                       horizontal: 10.0,
                       vertical: 5,
                     ),
-                    child: Column(
+                    child: ListView(
+                      shrinkWrap: true,
                       children: [
-                        Expanded(
-                          child: SingleChildScrollView(
-                            child: Column(
-                              mainAxisSize: MainAxisSize.min,
-                              children: [
                                 // Wallet balance section
                                 Consumer<UserProvider>(
                                   builder: (context, userProvider, _) {


### PR DESCRIPTION
## Summary
- prevent date/time list from overflowing by using a scrollable `ListView`

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851636a843c832893530cace4f1455d