### PR TITLE
Add buy now shortcut

### DIFF
--- a/lib/Screen/FlashSaleProductList.dart
+++ b/lib/Screen/FlashSaleProductList.dart
@@ -19,6 +19,8 @@ import '../app/routes.dart';
 import '../ui/styles/DesignConfig.dart';
 import '../ui/widgets/AppBarWidget.dart';
 import '../ui/widgets/AppBtn.dart';
+import '../ui/widgets/SimBtn.dart';
+import 'cart/Cart.dart';
 import 'HomePage.dart';
 
 class FlashProductList extends StatefulWidget {
@@ -175,7 +177,7 @@ class StateFlashList extends State<FlashProductList>
   }
 
   Future<void> addToCart(
-      int index, String qty, int from, FlashSaleModel data,) async {
+      int index, String qty, int from, FlashSaleModel data,{bool intent = false}) async {
     try {
       final Product model = data.products!.product![index];
       _isNetworkAvail = await isNetworkAvailable();
@@ -217,6 +219,15 @@ class StateFlashList extends State<FlashProductList>
                 setState(() {
                   _isProgress = false;
                 });
+                if (intent) {
+                  cartTotalClear();
+                  Navigator.push(
+                    context,
+                    CupertinoPageRoute(
+                      builder: (context) => const Cart(fromBottom: false),
+                    ),
+                  );
+                }
               }
             }, onError: (error) {
               setSnackbar(error.toString(), context);
@@ -275,6 +286,15 @@ class StateFlashList extends State<FlashProductList>
           setState(() {
             _isProgress = false;
           });
+          if (intent) {
+            cartTotalClear();
+            Navigator.push(
+              context,
+              CupertinoPageRoute(
+                builder: (context) => const Cart(fromBottom: false),
+              ),
+            );
+          }
         }
       } else {
         if (mounted) {
@@ -884,19 +904,38 @@ class StateFlashList extends State<FlashProductList>
                     ),
                   ),
                   Padding(
-                    padding:
-                        const EdgeInsetsDirectional.only(start: 5.0, bottom: 5),
-                    child: Text(
-                      model.name!,
-                      style: Theme.of(context).textTheme.titleMedium!.copyWith(
-                          color: Theme.of(context).colorScheme.lightBlack,),
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                    ),
+                  padding:
+                      const EdgeInsetsDirectional.only(start: 5.0, bottom: 5),
+                  child: Text(
+                    model.name!,
+                    style: Theme.of(context).textTheme.titleMedium!.copyWith(
+                        color: Theme.of(context).colorScheme.lightBlack,),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
                   ),
-                ],
-              ),
-              onTap: () {
+                ),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 5.0),
+                  child: SimBtn(
+                    width: 0.9,
+                    height: 30,
+                    title: getTranslated(context, 'BUYNOW2'),
+                    onBtnSelected: () {
+                      addToCart(
+                        index,
+                        (int.parse(_controller[index].text) +
+                                int.parse(model.qtyStepSize!))
+                            .toString(),
+                        1,
+                        dataModel,
+                        intent: true,
+                      );
+                    },
+                  ),
+                ),
+              ],
+            ),
+            onTap: () {
                 final Product model = dataModel.products!.product![index];
                 currentHero = saleSecHero;
                 Navigator.pushNamed(context, Routers.productDetails,

--- a/lib/Screen/ProductList.dart
+++ b/lib/Screen/ProductList.dart
@@ -25,6 +25,7 @@ import '../Model/Section_Model.dart';
 import '../ui/styles/DesignConfig.dart';
 import '../ui/widgets/AppBarWidget.dart';
 import '../utils/blured_router.dart';
+import 'cart/Cart.dart';
 import 'HomePage.dart';
 import 'Search.dart';
 
@@ -942,6 +943,15 @@ class StateProduct extends State<ProductListScreen>
                 .map((cart) => SectionModel.fromCart(cart))
                 .toList();
             context.read<CartProvider>().setCartlist(cartList);
+            if (intent) {
+              cartTotalClear();
+              Navigator.push(
+                context,
+                CupertinoPageRoute(
+                  builder: (context) => const Cart(fromBottom: false),
+                ),
+              );
+            }
           } else {
             setSnackbar(msg!, context);
           }
@@ -1752,6 +1762,24 @@ class StateProduct extends State<ProductListScreen>
                       overflow: TextOverflow.ellipsis,
                     ),
                   ),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 5.0),
+                    child: SimBtn(
+                      width: 0.9,
+                      height: 30,
+                      title: getTranslated(context, 'BUYNOW2'),
+                      onBtnSelected: () {
+                        addToCart(
+                          index,
+                          (int.parse(_controller[index].text) +
+                                  int.parse(model.qtyStepSize!))
+                              .toString(),
+                          1,
+                          intent: true,
+                        );
+                      },
+                    ),
+                  ),
                 ],
               ),
             ),
@@ -1993,7 +2021,7 @@ class StateProduct extends State<ProductListScreen>
     );
   }
 
-  Future<void> addToCart(int index, String qty, int from) async {
+  Future<void> addToCart(int index, String qty, int from, {bool intent = false}) async {
     _isNetworkAvail = await isNetworkAvailable();
     if (_isNetworkAvail) {
       if (context.read<UserProvider>().userId != "") {

--- a/lib/Screen/Sale_Section.dart
+++ b/lib/Screen/Sale_Section.dart
@@ -19,6 +19,7 @@ import '../ui/styles/DesignConfig.dart';
 import '../ui/widgets/AppBarWidget.dart';
 import '../ui/widgets/AppBtn.dart';
 import '../ui/widgets/SimBtn.dart';
+import 'cart/Cart.dart';
 import '../utils/blured_router.dart';
 import 'HomePage.dart';
 
@@ -849,7 +850,7 @@ class StateSection extends State<SaleSectionScreen>
     }
   }
 
-  Future<void> addToCart(int index, String qty, int from) async {
+  Future<void> addToCart(int index, String qty, int from, {bool intent = false}) async {
     try {
       final Product model = widget.section_model!.productList![index];
       _isNetworkAvail = await isNetworkAvailable();
@@ -886,6 +887,15 @@ class StateSection extends State<SaleSectionScreen>
                 setState(() {
                   _isProgress = false;
                 });
+                if (intent) {
+                  cartTotalClear();
+                  Navigator.push(
+                    context,
+                    CupertinoPageRoute(
+                      builder: (context) => const Cart(fromBottom: false),
+                    ),
+                  );
+                }
               }
             }, onError: (error) {
               setSnackbar(error.toString(), context);
@@ -893,10 +903,19 @@ class StateSection extends State<SaleSectionScreen>
           } on TimeoutException catch (_) {
             setSnackbar(getTranslated(context, 'somethingMSg')!, context);
             if (mounted) {
-              setState(() {
-                _isProgress = false;
-              });
-            }
+        setState(() {
+          _isProgress = false;
+        });
+        if (intent) {
+          cartTotalClear();
+          Navigator.push(
+            context,
+            CupertinoPageRoute(
+              builder: (context) => const Cart(fromBottom: false),
+            ),
+          );
+        }
+      }
           }
         } else {
           setState(() {
@@ -2101,6 +2120,24 @@ class StateSection extends State<SaleSectionScreen>
                                         .lightBlack,),
                             maxLines: 1,
                             overflow: TextOverflow.ellipsis,
+                          ),
+                        ),
+                        Padding(
+                          padding: const EdgeInsets.symmetric(horizontal: 5.0),
+                          child: SimBtn(
+                            width: 0.9,
+                            height: 30,
+                            title: getTranslated(context, 'BUYNOW2'),
+                            onBtnSelected: () {
+                              addToCart(
+                                index,
+                                (int.parse(_controller[index].text) +
+                                        int.parse(model.qtyStepSize!))
+                                    .toString(),
+                                1,
+                                intent: true,
+                              );
+                            },
                           ),
                         ),
                       ],


### PR DESCRIPTION
## Summary
- add optional checkout intent to `addToCart`
- add Buy Now buttons to product cards

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851650000ac8328a5857a929fd3c01f