### PR TITLE
Fix date picker overflow and add Buy Now

### DIFF
--- a/lib/Screen/Payment.dart
+++ b/lib/Screen/Payment.dart
@@ -274,7 +274,7 @@ class StatePayment extends State<Payment> with TickerProviderStateMixin {
                               ),
                               const Divider(),
                               Container(
-                                height: 90,
+                                height: 100,
                                 padding: const EdgeInsets.symmetric(horizontal: 10),
                                 child: ListView.builder(
                                   shrinkWrap: true,
@@ -420,10 +420,19 @@ class StatePayment extends State<Payment> with TickerProviderStateMixin {
       ),
       onTap: () {
         final DateTime date = today.add(Duration(days: index));
-        if (mounted) selectedDate = index;
-        selectedTime = null;
-        selTime = null;
-        selDate = DateFormat('yyyy-MM-dd').format(date);
+        if (mounted) {
+          setState(() {
+            selectedDate = index;
+            selectedTime = null;
+            selTime = null;
+            selDate = DateFormat('yyyy-MM-dd').format(date);
+          });
+        } else {
+          selectedDate = index;
+          selectedTime = null;
+          selTime = null;
+          selDate = DateFormat('yyyy-MM-dd').format(date);
+        }
         timeModel.clear();
         final DateTime cur = DateTime.now();
         final DateTime tdDate = DateTime(cur.year, cur.month, cur.day);

--- a/lib/Screen/cart/Cart.dart
+++ b/lib/Screen/cart/Cart.dart
@@ -5197,7 +5197,7 @@ Widget address() {
                 Column(
                   children: [
                     SizedBox(
-                      height: 80,
+                      height: 100,
                       child: ListView.builder(
                         scrollDirection: Axis.horizontal,
                         itemCount: int.parse(allowDay ?? '0'),
@@ -5761,10 +5761,19 @@ Widget address() {
         ),
         onTap: () {
           final DateTime date = today.add(Duration(days: index));
-          if (mounted) selectedDate = index;
-          selectedTime = null;
-          selTime = null;
-          selDate = DateFormat('yyyy-MM-dd').format(date);
+          if (mounted) {
+            setState(() {
+              selectedDate = index;
+              selectedTime = null;
+              selTime = null;
+              selDate = DateFormat('yyyy-MM-dd').format(date);
+            });
+          } else {
+            selectedDate = index;
+            selectedTime = null;
+            selTime = null;
+            selDate = DateFormat('yyyy-MM-dd').format(date);
+          }
           timeModel.clear();
           final DateTime cur = DateTime.now();
           final DateTime tdDate = DateTime(cur.year, cur.month, cur.day);

--- a/lib/ui/widgets/product_list_content.dart
+++ b/lib/ui/widgets/product_list_content.dart
@@ -26,6 +26,7 @@ import '../styles/DesignConfig.dart';
 import '../../utils/blured_router.dart';
 import '../../Screen/HomePage.dart';
 import '../../Screen/Search.dart';
+import '../../Screen/cart/Cart.dart';
 
 class ProductListContent extends StatefulWidget {
   final String? name;
@@ -931,6 +932,15 @@ class StateProduct extends State<ProductListContent>
                 .map((cart) => SectionModel.fromCart(cart))
                 .toList();
             context.read<CartProvider>().setCartlist(cartList);
+            if (intent) {
+              cartTotalClear();
+              Navigator.push(
+                context,
+                CupertinoPageRoute(
+                  builder: (context) => const Cart(fromBottom: false),
+                ),
+              );
+            }
           } else {
             setSnackbar(msg!, context);
           }
@@ -1742,6 +1752,24 @@ if (widget.id != null) {
                       overflow: TextOverflow.ellipsis,
                     ),
                   ),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 5.0),
+                    child: SimBtn(
+                      width: 0.9,
+                      height: 30,
+                      title: getTranslated(context, 'BUYNOW2'),
+                      onBtnSelected: () async {
+                        await addToCart(
+                          index,
+                          (int.parse(_controller[index].text) +
+                                  int.parse(model.qtyStepSize!))
+                              .toString(),
+                          1,
+                          intent: true,
+                        );
+                      },
+                    ),
+                  ),
                 ],
               ),
             ),
@@ -1983,7 +2011,7 @@ if (widget.id != null) {
     );
   }
 
-  Future<void> addToCart(int index, String qty, int from) async {
+  Future<void> addToCart(int index, String qty, int from, {bool intent = false}) async {
     _isNetworkAvail = await isNetworkAvailable();
     if (_isNetworkAvail) {
       if (context.read<UserProvider>().userId != "") {


### PR DESCRIPTION
## Summary
- fix overflow in checkout time slot widget
- improve immediate highlighting when date is tapped
- extend cart screen height for time slot list
- show Buy Now button on product lists and allow direct checkout

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68516f45d7ac8328a565de158d15da30