### PR TITLE
Fix buy-now flow and date highlight

### DIFF
--- a/lib/Screen/FlashSaleProductList.dart
+++ b/lib/Screen/FlashSaleProductList.dart
@@ -224,7 +224,10 @@ class StateFlashList extends State<FlashProductList>
                   Navigator.push(
                     context,
                     CupertinoPageRoute(
-                      builder: (context) => const Cart(fromBottom: false),
+                      builder: (context) => const Cart(
+                        fromBottom: false,
+                        buyNow: true,
+                      ),
                     ),
                   );
                 }
@@ -291,7 +294,10 @@ class StateFlashList extends State<FlashProductList>
             Navigator.push(
               context,
               CupertinoPageRoute(
-                builder: (context) => const Cart(fromBottom: false),
+                builder: (context) => const Cart(
+                  fromBottom: false,
+                  buyNow: true,
+                ),
               ),
             );
           }

--- a/lib/Screen/ProductList.dart
+++ b/lib/Screen/ProductList.dart
@@ -948,7 +948,10 @@ class StateProduct extends State<ProductListScreen>
               Navigator.push(
                 context,
                 CupertinoPageRoute(
-                  builder: (context) => const Cart(fromBottom: false),
+                  builder: (context) => const Cart(
+                    fromBottom: false,
+                    buyNow: true,
+                  ),
                 ),
               );
             }

--- a/lib/Screen/Product_DetailNew.dart
+++ b/lib/Screen/Product_DetailNew.dart
@@ -1598,6 +1598,7 @@ class StateItem extends State<ProductDetail> with TickerProviderStateMixin {
                       CupertinoPageRoute(
                         builder: (context) => const Cart(
                           fromBottom: false,
+                          buyNow: true,
                         ),
                       ),
                     );
@@ -1651,6 +1652,7 @@ class StateItem extends State<ProductDetail> with TickerProviderStateMixin {
                     CupertinoPageRoute(
                       builder: (context) => const Cart(
                         fromBottom: false,
+                        buyNow: true,
                       ),
                     ),
                   );

--- a/lib/Screen/Sale_Section.dart
+++ b/lib/Screen/Sale_Section.dart
@@ -892,7 +892,10 @@ class StateSection extends State<SaleSectionScreen>
                   Navigator.push(
                     context,
                     CupertinoPageRoute(
-                      builder: (context) => const Cart(fromBottom: false),
+                      builder: (context) => const Cart(
+                        fromBottom: false,
+                        buyNow: true,
+                      ),
                     ),
                   );
                 }
@@ -911,7 +914,10 @@ class StateSection extends State<SaleSectionScreen>
           Navigator.push(
             context,
             CupertinoPageRoute(
-              builder: (context) => const Cart(fromBottom: false),
+              builder: (context) => const Cart(
+                fromBottom: false,
+                buyNow: true,
+              ),
             ),
           );
         }

--- a/lib/Screen/cart/Cart.dart
+++ b/lib/Screen/cart/Cart.dart
@@ -58,7 +58,8 @@ import '../../utils/Hive/hive_utils.dart';
 
   class Cart extends StatefulWidget {
     final bool fromBottom;
-    const Cart({super.key, required this.fromBottom});
+    final bool buyNow;
+    const Cart({super.key, required this.fromBottom, this.buyNow = false});
     @override
     State<StatefulWidget> createState() => StateCart();
   }
@@ -2219,6 +2220,11 @@ buildConvertedPrice(
               setState(() {
                 _isCartLoad = false;
               });
+              if (widget.buyNow) {
+                WidgetsBinding.instance.addPostFrameCallback((_) {
+                  checkout();
+                });
+              }
             }
           },
           onError: (error) {
@@ -2293,6 +2299,11 @@ buildConvertedPrice(
                   setState(() {
                     _isCartLoad = false;
                   });
+                  if (widget.buyNow) {
+                    WidgetsBinding.instance.addPostFrameCallback((_) {
+                      checkout();
+                    });
+                  }
                 }
               },
               onError: (error) {
@@ -2314,6 +2325,11 @@ buildConvertedPrice(
         setState(() {
           _isCartLoad = false;
         });
+        if (widget.buyNow) {
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            checkout();
+          });
+        }
       }
     }
 
@@ -5762,7 +5778,7 @@ Widget address() {
         onTap: () {
           final DateTime date = today.add(Duration(days: index));
           if (mounted) {
-            setState(() {
+            checkoutState?.call(() {
               selectedDate = index;
               selectedTime = null;
               selTime = null;
@@ -5810,7 +5826,7 @@ Widget address() {
               }
             }
           }
-          setState(() {});
+          checkoutState?.call(() {});
         },
       );
     }
@@ -5820,7 +5836,7 @@ Widget address() {
       return InkWell(
         onTap: () {
           if (mounted) {
-            setState(() {
+            checkoutState?.call(() {
               selectedTime = index;
               selTime = timeModel[selectedTime!].name;
               for (final element in timeModel) {

--- a/lib/ui/widgets/product_list_content.dart
+++ b/lib/ui/widgets/product_list_content.dart
@@ -937,7 +937,10 @@ class StateProduct extends State<ProductListContent>
               Navigator.push(
                 context,
                 CupertinoPageRoute(
-                  builder: (context) => const Cart(fromBottom: false),
+                  builder: (context) => const Cart(
+                    fromBottom: false,
+                    buyNow: true,
+                  ),
                 ),
               );
             }


### PR DESCRIPTION
## Summary
- show checkout date selection highlight using bottom sheet state
- add buy-now argument to `Cart`
- navigate directly to checkout when pressing Buy Now from product listings

## Testing
- `flutter` commands could not be run due to missing environment

------
https://chatgpt.com/codex/tasks/task_e_6851750e18b88328ae2e52500d395b2c