### PR TITLE
Add Buy Now checkout path

### DIFF
--- a/lib/Screen/ProductList.dart
+++ b/lib/Screen/ProductList.dart
@@ -2132,6 +2132,18 @@ class StateProduct extends State<ProductListScreen>
         setState(() {
           _isProgress = false;
         });
+    if (intent) {
+      cartTotalClear();
+      Navigator.push(
+        context,
+        CupertinoPageRoute(
+          builder: (context) => const Cart(
+            fromBottom: false,
+            buyNow: true,
+          ),
+        ),
+      );
+    }
       }
     } else {
       if (mounted) {

--- a/lib/ui/widgets/product_list_content.dart
+++ b/lib/ui/widgets/product_list_content.dart
@@ -665,6 +665,22 @@ class StateProduct extends State<ProductListContent>
                                       )
                                     else
                                       const SizedBox.shrink(),
+                                    Padding(
+                                      padding: const EdgeInsets.symmetric(horizontal: 5.0),
+                                      child: SimBtn(
+                                        width: 0.9,
+                                        height: 30,
+                                        title: getTranslated(context, 'BUYNOW2'),
+                                        onBtnSelected: () {
+                                          addToCart(
+                                            index,
+                                            (int.parse(_controller[index].text) + int.parse(model.qtyStepSize!)).toString(),
+                                            1,
+                                            intent: true,
+                                          );
+                                        },
+                                      ),
+                                    ),
                                   ],
                                 ),
                               ),
@@ -2122,6 +2138,18 @@ if (widget.id != null) {
         setState(() {
           _isProgress = false;
         });
+    if (intent) {
+      cartTotalClear();
+      Navigator.push(
+        context,
+        CupertinoPageRoute(
+          builder: (context) => const Cart(
+            fromBottom: false,
+            buyNow: true,
+          ),
+        ),
+      );
+    }
       }
     } else {
       if (mounted) {


### PR DESCRIPTION
## Summary
- add "Buy Now" button in list view
- navigate to checkout when using "Buy Now" in list and grid views

## Testing
- `dart format lib/Screen/ProductList.dart lib/ui/widgets/product_list_content.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68528a4711b48328900a1f381eec94ee