### PR TITLE
Fix Buy Now button navigation

### DIFF
--- a/lib/Screen/FlashSaleProductList.dart
+++ b/lib/Screen/FlashSaleProductList.dart
@@ -926,8 +926,8 @@ class StateFlashList extends State<FlashProductList>
                     width: 0.9,
                     height: 30,
                     title: getTranslated(context, 'BUYNOW2'),
-                    onBtnSelected: () {
-                      addToCart(
+                    onBtnSelected: () async {
+                      await addToCart(
                         index,
                         (int.parse(_controller[index].text) +
                                 int.parse(model.qtyStepSize!))

--- a/lib/Screen/ProductList.dart
+++ b/lib/Screen/ProductList.dart
@@ -1771,8 +1771,8 @@ class StateProduct extends State<ProductListScreen>
                       width: 0.9,
                       height: 30,
                       title: getTranslated(context, 'BUYNOW2'),
-                      onBtnSelected: () {
-                        addToCart(
+                      onBtnSelected: () async {
+                        await addToCart(
                           index,
                           (int.parse(_controller[index].text) +
                                   int.parse(model.qtyStepSize!))

--- a/lib/Screen/Sale_Section.dart
+++ b/lib/Screen/Sale_Section.dart
@@ -2134,8 +2134,8 @@ class StateSection extends State<SaleSectionScreen>
                             width: 0.9,
                             height: 30,
                             title: getTranslated(context, 'BUYNOW2'),
-                            onBtnSelected: () {
-                              addToCart(
+                            onBtnSelected: () async {
+                              await addToCart(
                                 index,
                                 (int.parse(_controller[index].text) +
                                         int.parse(model.qtyStepSize!))

--- a/lib/ui/widgets/product_list_content.dart
+++ b/lib/ui/widgets/product_list_content.dart
@@ -671,8 +671,8 @@ class StateProduct extends State<ProductListContent>
                                         width: 0.9,
                                         height: 30,
                                         title: getTranslated(context, 'BUYNOW2'),
-                                        onBtnSelected: () {
-                                          addToCart(
+                                        onBtnSelected: () async {
+                                          await addToCart(
                                             index,
                                             (int.parse(_controller[index].text) + int.parse(model.qtyStepSize!)).toString(),
                                             1,


### PR DESCRIPTION
## Summary
- ensure Buy Now buttons await add-to-cart actions
- make Buy Now buttons navigate directly to checkout

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685294a02a048328ae4bc7d219db6546