### PR TITLE
Fix layout for buy now button

### DIFF
--- a/lib/ui/widgets/product_list_content.dart
+++ b/lib/ui/widgets/product_list_content.dart
@@ -551,10 +551,8 @@ class StateProduct extends State<ProductListContent>
                                     ),
                                     Padding(
                                       padding: const EdgeInsets.symmetric(horizontal: 5.0),
-                                      child: Wrap(
-                                        spacing: 5,
-                                        runSpacing: 5,
-                                        crossAxisAlignment: WrapCrossAlignment.center,
+                                      child: Column(
+                                        crossAxisAlignment: CrossAxisAlignment.start,
                                         children: [
                                           if (_controller[index].text != "0" &&
                                               model.availability != "0" &&
@@ -646,9 +644,10 @@ class StateProduct extends State<ProductListContent>
                                                     );
                                                   },
                                                 ),
-                                              ],
-                                            ),
-                                          SizedBox(
+                                               ],
+                                             ),
+                                           const SizedBox(height: 5),
+                                           SizedBox(
                                             width: 110,
                                             height: 32,
                                             child: SimBtn(


### PR DESCRIPTION
## Summary
- avoid overflow in product list view by placing the Buy Now button on its own row

## Testing
- `Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_6852b55a9aa0832891166422697512bf