### PR TITLE
Fix Buy Now login flow

### DIFF
--- a/lib/Screen/ProductList.dart
+++ b/lib/Screen/ProductList.dart
@@ -685,12 +685,29 @@ class StateProduct extends State<ProductListScreen>
                                                   backgroundColor: Theme.of(context).colorScheme.primarytheme,
                                                 ),
                                                 onPressed: () {
-                                                  addToCart(
-                                                    index,
-                                                    (int.parse(_controller[index].text) + int.parse(model.qtyStepSize!)).toString(),
-                                                    1,
-                                                    intent: true,
-                                                  );
+                                                  final String userId = context.read<UserProvider>().userId;
+                                                  if (userId.isEmpty) {
+                                                    addToCart(
+                                                      index,
+                                                      (int.parse(_controller[index].text) + int.parse(model.qtyStepSize!)).toString(),
+                                                      1,
+                                                    );
+                                                    Navigator.pushNamed(
+                                                      context,
+                                                      Routers.loginScreen,
+                                                      arguments: {
+                                                        "isPop": false,
+                                                        "classType": const Cart(fromBottom: false, buyNow: true),
+                                                      },
+                                                    );
+                                                  } else {
+                                                    addToCart(
+                                                      index,
+                                                      (int.parse(_controller[index].text) + int.parse(model.qtyStepSize!)).toString(),
+                                                      1,
+                                                      intent: true,
+                                                    );
+                                                  }
                                                 },
                                                 child: Text(
                                                   getTranslated(context, 'BUYNOW2'),
@@ -1808,14 +1825,33 @@ class StateProduct extends State<ProductListScreen>
                         height: 28,
                         title: getTranslated(context, 'BUYNOW2'),
                         onBtnSelected: () async {
-                          await addToCart(
-                            index,
-                            (int.parse(_controller[index].text) +
-                                    int.parse(model.qtyStepSize!))
-                                .toString(),
-                            1,
-                            intent: true,
-                          );
+                          final String userId = context.read<UserProvider>().userId;
+                          if (userId.isEmpty) {
+                            await addToCart(
+                              index,
+                              (int.parse(_controller[index].text) +
+                                      int.parse(model.qtyStepSize!))
+                                  .toString(),
+                              1,
+                            );
+                            Navigator.pushNamed(
+                              context,
+                              Routers.loginScreen,
+                              arguments: {
+                                "isPop": false,
+                                "classType": const Cart(fromBottom: false, buyNow: true),
+                              },
+                            );
+                          } else {
+                            await addToCart(
+                              index,
+                              (int.parse(_controller[index].text) +
+                                      int.parse(model.qtyStepSize!))
+                                  .toString(),
+                              1,
+                              intent: true,
+                            );
+                          }
                         },
                       ),
                     ),

--- a/lib/ui/widgets/product_list_content.dart
+++ b/lib/ui/widgets/product_list_content.dart
@@ -650,19 +650,40 @@ class StateProduct extends State<ProductListContent>
                                            SizedBox(
                                             width: 110,
                                             height: 32,
-                                            child: SimBtn(
-                                              width: 1,
-                                              height: 32,
-                                              title: getTranslated(context, 'BUYNOW2'),
-                                              onBtnSelected: () async {
+                                          child: SimBtn(
+                                            width: 1,
+                                            height: 32,
+                                            title: getTranslated(context, 'BUYNOW2'),
+                                            onBtnSelected: () async {
+                                              final String userId = context.read<UserProvider>().userId;
+                                              if (userId.isEmpty) {
                                                 await addToCart(
                                                   index,
-                                                  (int.parse(_controller[index].text) + int.parse(model.qtyStepSize!)).toString(),
+                                                  (int.parse(_controller[index].text) +
+                                                          int.parse(model.qtyStepSize!))
+                                                      .toString(),
+                                                  1,
+                                                );
+                                                Navigator.pushNamed(
+                                                  context,
+                                                  Routers.loginScreen,
+                                                  arguments: {
+                                                    "isPop": false,
+                                                    "classType": const Cart(fromBottom: false, buyNow: true),
+                                                  },
+                                                );
+                                              } else {
+                                                await addToCart(
+                                                  index,
+                                                  (int.parse(_controller[index].text) +
+                                                          int.parse(model.qtyStepSize!))
+                                                      .toString(),
                                                   1,
                                                   intent: true,
                                                 );
-                                              },
-                                            ),
+                                              }
+                                            },
+                                          ),
                                           ),
                                         ],
                                       ),
@@ -1864,13 +1885,33 @@ if (widget.id != null) {
                             height: 32,
                             title: getTranslated(context, 'BUYNOW2'),
                             onBtnSelected: () async {
-                              await addToCart(
-                                index,
-                                (int.parse(_controller[index].text) + int.parse(model.qtyStepSize!))
-                                    .toString(),
-                                1,
-                                intent: true,
-                              );
+                              final String userId = context.read<UserProvider>().userId;
+                              if (userId.isEmpty) {
+                                await addToCart(
+                                  index,
+                                  (int.parse(_controller[index].text) +
+                                          int.parse(model.qtyStepSize!))
+                                      .toString(),
+                                  1,
+                                );
+                                Navigator.pushNamed(
+                                  context,
+                                  Routers.loginScreen,
+                                  arguments: {
+                                    "isPop": false,
+                                    "classType": const Cart(fromBottom: false, buyNow: true),
+                                  },
+                                );
+                              } else {
+                                await addToCart(
+                                  index,
+                                  (int.parse(_controller[index].text) +
+                                          int.parse(model.qtyStepSize!))
+                                      .toString(),
+                                  1,
+                                  intent: true,
+                                );
+                              }
                             },
                           ),
                         ),


### PR DESCRIPTION
## Summary
- route Buy Now to login if user is not signed in
- after login redirect to checkout via cart

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68568bbff634832898469b8350194ef2